### PR TITLE
remove jupyterlab from setup.py, it is not used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ setuptools.setup(
         'nest-asyncio',
         'numpy',
         'sty',
-        'pyzmq<20.0.0',
-        'jupyterlab',
         'dill',
         'python-dotenv',
         'fsspec',


### PR DESCRIPTION
Jupyterlab is the cause of some recent dependency problems. Since it is not used, we should just remove it from setup.py. In later version of cowait it is removed.